### PR TITLE
Handling of fs.exists in a backwards compatible way

### DIFF
--- a/lib/attachments.js
+++ b/lib/attachments.js
@@ -22,6 +22,7 @@ var im = require('imagemagick');
 var fs = require('fs');
 var path = require('path');
 var async = require('async');
+var existsFn = fs.exists || path.exists;
 
 // keeps a global registry of storage providers
 var providersRegistry = {};
@@ -101,7 +102,7 @@ var plugin = function(schema, options) {
       // No original name provided? We infer it from the path
       attachmentInfo.name = path.basename(attachmentInfo.path);
     }
-    path.exists(attachmentInfo.path, function(exists) {
+    existsFn(attachmentInfo.path, function(exists) {
       if(!exists) return cb(new Error('file to attach at path "' + attachmentInfo.path + '" does not exists'));
       fs.stat(attachmentInfo.path, function(err, stats) {
         if(!stats.isFile()) return cb(new Error('path to attach from "' + attachmentInfo.path + '" is not a file'));


### PR DESCRIPTION
Hi,

here is the backwards compatible fix.
The original ticket is https://github.com/firebaseco/mongoose-attachments/pull/2 .

Cheers,
Chantal
