### PR TITLE
Option to use ImageMagick formats for supportedDecodingFormats

### DIFF
--- a/lib/attachments.js
+++ b/lib/attachments.js
@@ -80,7 +80,9 @@ function findImageMagickFormats(options, callback) {
       }
       return callback(null,formats);
     } else {
-      return callback(new Error("No formats supported for read operation: 'convert -list format'"));
+      return callback(new Error("No format supports the requested operation(s): "
+                       + Object.keys(opts).toString()
+                       + " . Check 'convert -list format'"));
     }
   });
 }

--- a/lib/attachments.js
+++ b/lib/attachments.js
@@ -40,6 +40,51 @@ function findProvider(name) {
   return provider;
 }
 
+function findImageMagickFormats(options, callback) {
+  var opts = { read: true };
+  if (typeof options === 'function') {
+    callback = options;
+  } else if (options.read || options.write || options.multi || options.blob ) {
+    opts = options;
+  } else {
+    callback(new Error("Options have to contain one or more of 'read', 'write', 'multi', 'blob'"));
+  }
+  im.convert(['-list','format'], function(err, stdout, stderr) {
+    if (err) return callback(err);
+    if (stderr && stderr.search(/\S/) >= 0) return callback(new Error(stderr));
+    if (stdout && stdout.search(/\S/) >= 0) {
+      // capture groups:
+      // 0: all
+      // 1: format
+      // 2: if '*' = native blob support; if ' ' (whitespace) none
+      // 3: module
+      // 4: if 'r' = read support; if '-' none
+      // 5: if 'w' = write support; if '-' none
+      // 6: if '+' = support for multiple images; if '-' none
+      // 7: description
+      var regex = /^\s*([^\*\s]+)(\*|\s)\s(\S+)\s+([-r])([-w])([-+])\s+(.*)$/;
+      var lines = stdout.split("\n");
+      var comps = [];
+      var formats = [];
+      for (i in lines) {
+        currentLine = lines[i];
+        comps = regex.exec(currentLine);
+        if (comps) {
+          if ((!opts.read  || comps[4] === 'r') &&
+              (!opts.write || comps[5] === 'w') &&
+              (!opts.multi || comps[6] === '+') &&
+              (!opts.blob  || comps[2] === '*')) {
+            formats.push(comps[1]);
+          }
+        }
+      }
+      return callback(null,formats);
+    } else {
+      return callback(new Error("No formats supported for read operation: 'convert -list format'"));
+    }
+  });
+}
+
 var plugin = function(schema, options) {
   options = options || {};
   if(typeof(options.directory) !== 'string') throw new Error('option "directory" is required');
@@ -261,6 +306,37 @@ plugin.registerStorageProvider = function(name, provider) {
 // Register a Known Decoding Format(e.g 'PNG')
 plugin.registerDecodingFormat = function(name) {
   supportedDecodingFormats.push(name);
+}
+
+/*
+ * Use this to register all formats for which your local ImageMagick installation supports
+ * read operations.
+ */
+plugin.registerImageMagickDecodingFormats = function() {
+  plugin.registerImageMagickFormats({ read: true });
+}
+
+/*
+ * You can register formats based on certain modes or a combination of those:
+ * 'read' : true|false
+ * 'write': true|false
+ * 'multi': true|false
+ * 'blob' : true|false
+ * options is optional and defaults to { read: true }. If several modes with value true are given,
+ * only formats supporting all of them are included.
+ */
+plugin.registerImageMagickFormats = function(options, callback) {
+  if (!callback) {
+    callback = function(error, formats) {
+      if (error) throw new Error(error);
+      else if (formats && formats.length > 0) {
+        supportedDecodingFormats = formats;
+      } else {
+        throw new Error("No formats supported for decoding!");
+      }
+    };
+  }
+  findImageMagickFormats(options, callback);
 }
 
 // Export the Plugin for mongoose.js

--- a/lib/attachments.js
+++ b/lib/attachments.js
@@ -66,6 +66,7 @@ function findImageMagickFormats(options, callback) {
       var lines = stdout.split("\n");
       var comps = [];
       var formats = [];
+      var i;
       for (i in lines) {
         currentLine = lines[i];
         comps = regex.exec(currentLine);

--- a/lib/attachments.js
+++ b/lib/attachments.js
@@ -66,7 +66,7 @@ function findImageMagickFormats(options, callback) {
       var lines = stdout.split("\n");
       var comps = [];
       var formats = [];
-      var i;
+      var i, currentLine;
       for (i in lines) {
         currentLine = lines[i];
         comps = regex.exec(currentLine);

--- a/lib/attachments.js
+++ b/lib/attachments.js
@@ -56,13 +56,13 @@ function findImageMagickFormats(options, callback) {
       // capture groups:
       // 0: all
       // 1: format
-      // 2: if '*' = native blob support; if ' ' (whitespace) none
+      // 2: if '*' = native blob support; if ' ' (whitespace) none. Not set with graphicsmagick - therefore optional in regex
       // 3: module
       // 4: if 'r' = read support; if '-' none
       // 5: if 'w' = write support; if '-' none
       // 6: if '+' = support for multiple images; if '-' none
       // 7: description
-      var regex = /^\s*([^\*\s]+)(\*|\s)\s(\S+)\s+([-r])([-w])([-+])\s+(.*)$/;
+      var regex = /^\s*([^\*\s]+)(\*|\s)?\s(\S+)\s+([-r])([-w])([-+])\s+(.*)$/;
       var lines = stdout.split("\n");
       var comps = [];
       var formats = [];

--- a/test/testFindImageMagickFormats.js
+++ b/test/testFindImageMagickFormats.js
@@ -1,0 +1,78 @@
+var plugin = require('../lib/attachments');
+
+// NOTE that these tests have been created on MacOS 10.7.5 with ImageMagick 6.7.7-6 installed via homebrew
+// Call: node test/testFindImageMagickFormats.js
+// Tests have passed if no error has been thrown
+
+plugin.registerImageMagickDecodingFormats();
+
+plugin.registerImageMagickFormats({ read: true }, function(error, formats) {
+  if (error) console.log(error);
+  else {
+    //console.log("-----------ATT formats", formats);
+    if (formats.indexOf('DOT') >= 0) {
+      throw new Error ('DOT has no blob,read,write,multi support');
+    }
+    if (formats.indexOf('XPS') < 0) {
+      throw new Error ('XPS has read support');
+    }
+    if (formats.indexOf('UIL') >= 0) {
+      throw new Error ('UIL has no read,multi support');
+    }
+    console.log("read support passed");
+  }
+});
+
+plugin.registerImageMagickFormats({ write: true }, function(error, formats) {
+  if (error) console.log(error);
+  else {
+    //console.log("-----------ATT formats", formats);
+    if (formats.indexOf('DOT') >= 0) {
+      throw new Error ('DOT has no blob,read,write,multi support');
+    }
+    if (formats.indexOf('XPS') >= 0) {
+      throw new Error ('XPS has no write,multi support');
+    }
+    if (formats.indexOf('UIL') < 0) {
+      throw new Error ('UIL has write support');
+    }
+    console.log("write support passed");
+  }
+});
+
+plugin.registerImageMagickFormats({ write: true, blob: true }, function(error, formats) {
+  if (error) console.log(error);
+  else {
+    //console.log("-----------ATT formats", formats);
+    if (formats.indexOf('DOT') >= 0) {
+      throw new Error ('DOT has no blob,read,write,multi support');
+    }
+    if (formats.indexOf('WMV') >= 0) {
+      throw new Error ('XPS has write but no blob support');
+    }
+    if (formats.indexOf('UIL') < 0) {
+      throw new Error ('UIL has write and blob support');
+    }
+    console.log("write and blob support passed");
+  }
+});
+
+plugin.registerImageMagickFormats({ read: true, multi: true }, function(error, formats) {
+  if (error) console.log(error);
+  else {
+    //console.log("-----------ATT formats", formats);
+    if (formats.indexOf('DOT') >= 0) {
+      throw new Error ('DOT has no blob,read,write,multi support');
+    }
+    if (formats.indexOf('XPS') >= 0) {
+      throw new Error ('XPS has read but no multi support');
+    }
+    if (formats.indexOf('UIL') >= 0) {
+      throw new Error ('UIL has no read,multi support');
+    }
+    if (formats.indexOf('X') < 0) {
+      throw new Error ('X has read and multi support');
+    }
+    console.log("read and multi support passed");
+  }
+});

--- a/test/testFindImageMagickFormats.js
+++ b/test/testFindImageMagickFormats.js
@@ -1,15 +1,18 @@
 var plugin = require('../lib/attachments');
 
 // NOTE that these tests have been created on MacOS 10.7.5 with ImageMagick 6.7.7-6 installed via homebrew
-// Call: node test/testFindImageMagickFormats.js
-// Tests have passed if no error has been thrown
+// Check that the formats in the tests match your installation by calling
+// 'convert -list format' and comparing the output
+//
+// CALL for test: node test/testFindImageMagickFormats.js
+//
+// Tests have passed if no error is thrown and the "<mode(s)> support passed" messages are printed.
 
 plugin.registerImageMagickDecodingFormats();
 
 plugin.registerImageMagickFormats({ read: true }, function(error, formats) {
   if (error) console.log(error);
   else {
-    //console.log("-----------ATT formats", formats);
     if (formats.indexOf('DOT') >= 0) {
       throw new Error ('DOT has no blob,read,write,multi support');
     }
@@ -26,7 +29,6 @@ plugin.registerImageMagickFormats({ read: true }, function(error, formats) {
 plugin.registerImageMagickFormats({ write: true }, function(error, formats) {
   if (error) console.log(error);
   else {
-    //console.log("-----------ATT formats", formats);
     if (formats.indexOf('DOT') >= 0) {
       throw new Error ('DOT has no blob,read,write,multi support');
     }
@@ -43,7 +45,6 @@ plugin.registerImageMagickFormats({ write: true }, function(error, formats) {
 plugin.registerImageMagickFormats({ write: true, blob: true }, function(error, formats) {
   if (error) console.log(error);
   else {
-    //console.log("-----------ATT formats", formats);
     if (formats.indexOf('DOT') >= 0) {
       throw new Error ('DOT has no blob,read,write,multi support');
     }
@@ -60,7 +61,6 @@ plugin.registerImageMagickFormats({ write: true, blob: true }, function(error, f
 plugin.registerImageMagickFormats({ read: true, multi: true }, function(error, formats) {
   if (error) console.log(error);
   else {
-    //console.log("-----------ATT formats", formats);
     if (formats.indexOf('DOT') >= 0) {
       throw new Error ('DOT has no blob,read,write,multi support');
     }


### PR DESCRIPTION
Hi,

there is a new method that parses the output of 'convert -list format'. It is able to check for all the modes: read, write, multi (support for multiple images), blob (native blob support). The modes can be combined.

I've also added the function

```
plugin.registerImageMagickDecodingFormat()
```

which populates supportedDecodingFormats with all ImageMagick formats supporting 'read'. This function has to be called explicitly before configuring the mongoose model - otherwise the plugin behaves as before.

Maybe it would be good to change the default behaviour but that is something for you to decide.

Reasons for making it the default (IMHO):
- The current list is hard coded and includes TIFF but TIFF is not a format which is included by default in ImageMagick on all operating systems. For example, on my mac, it's not supported (not even listed). See here:
  http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=20635
  It's probably handled correctly because of identify() but it's not that nice to include it in the hard coded list like its support would be granted?
- Why have a hard coded list if the actual list of formats supported by ImageMagick is available? If a client wants to filter on certain formats they should do that outside of mongoose-attachments - they should be validating the user input before even calling 'save'.

This pull request also contains a /test/ folder and a test script. I have not added any test frameworks, though. The test is simply called with node from the commandline.

Once it is in, the README should be updated appropriately. (I can do that.)

Cheers,
Chantal
