### PR TITLE
FsStorage : provider implementation to store images in local file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Assuming that the HTML form sent a file in a field called 'image':
 
 #### Using Local Storage
 
-    // further up: var path = require('path'),
+    // further up: var path = require('path');
     
     MySchema.plugin(attachments, {
       directory: '/absolute/path/to/public/images',

--- a/README.md
+++ b/README.md
@@ -82,6 +82,43 @@ Assuming that the HTML form sent a file in a field called 'image':
         });
     })	
 
+#### Using Local Storage
+
+    // further up: var path = require('path'),
+    
+    MySchema.plugin(attachments, {
+      directory: '/absolute/path/to/public/images',
+      storage : {
+        providerName: 'fs'
+      },
+      properties: {
+        image: {
+          styles: {
+            original: {
+              // keep the original file
+            },
+            thumb: {
+              thumbnail: '100x100^',
+              gravity: 'center',
+              extent: '100x100',
+              '$format': 'jpg'
+            },
+            detail: {
+              resize: '400x400>',
+              '$format': 'jpg'
+            }
+          }
+        }
+      }
+    });
+    MySchema.virtual('detail_img').get(function() {
+      return path.join('detail', path.basename(this.image.detail.path));
+    });
+    MySchema.virtual('thumb_img').get(function() {
+      return path.join('thumb', path.basename(this.image.thumb.path));
+    });
+
+The URL to the images would then be `http://<your host>/<mount path>/images` prepended to the value of `MyModel.detail_img` and `MyModel.thumb_img`.
 
 ### Metadata
 

--- a/lib/providers/localfs.js
+++ b/lib/providers/localfs.js
@@ -1,0 +1,86 @@
+// Copyright (c) 2012 IT Agenten - http://www.it-agenten.com
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+// This 'provider' stores the images created via mongoose-attachments in the
+// local file system.
+// It requires that the option 'directory' points to the absolute path of
+// the directory where it will create subfolders per image type.
+//
+// Example:
+// type is 'thumb'
+// and 'directory' points to /path/to/public/images/
+// When storing data into the schema, the thumbnail created by mongoose-attachemnts
+// is stored as /path/to/public/images/thumb/<ObjectID>-thumb.<format>
+//
+// The absolute path to the image is stored in Model.image.<type>.path
+
+var attachments = require('mongoose-attachments');
+var fs = require('fs');
+var path = require('path');
+var util = require('util');
+
+function FsStorage(options) {
+	attachments.StorageProvider.call(this, options);
+}
+util.inherits(FsStorage, attachments.StorageProvider);
+
+/*
+ * Returns the file system path (absolute)
+ * and not the actual URL.
+ */
+FsStorage.prototype.getUrl = function( path ){
+	return path;
+};
+
+FsStorage.prototype.createOrReplace = function(attachment, callback) {
+	var self = this;
+	var dirname = path.join(path.dirname(attachment.path), attachment.style.name);
+	if (!fs.existsSync(dirname)) {
+		var pathParts = dirname.split(path.sep);
+		var p = "/";
+		for (var i=0; i<pathParts.length; i++) {
+			p = path.join(p, pathParts[i]);
+			if (!fs.existsSync(p)) {
+				fs.mkdirSync(p, '0750');
+			}
+		}
+	}
+
+	var basename = path.basename(attachment.path);
+	if (path.extname(basename).length == 0) {
+		basename = basename + "." + attachment.model.extension;
+	}
+	attachment.path = path.join(dirname, basename);
+	fs.rename(attachment.filename, attachment.path, function(error) {
+		if (error) {
+			callback(error);
+		} else {
+			attachment.defaultUrl = self.getUrl( attachment.path );
+			callback(null, attachment);
+		}
+	});
+};
+
+// register the File System Storage Provider into the registry
+attachments.registerStorageProvider('fs', FsStorage);
+
+// export it just in case the user needs it
+module.exports = FsStorage;

--- a/lib/providers/localfs.js
+++ b/lib/providers/localfs.js
@@ -32,7 +32,7 @@
 //
 // The absolute path to the image is stored in Model.image.<type>.path
 
-var attachments = require('mongoose-attachments');
+var attachments = require('../attachments');
 var fs = require('fs');
 var path = require('path');
 var util = require('util');


### PR DESCRIPTION
Hi Johan,

I have created another provider to store the images locally which I am allowed to contribute (by courtesy of IT Agenten https://github.com/itagenten).

Disclaimer:
We have been using this FsStorage for a while, now, but only in testing envrionments. Also, the script was (is still) a part of our app, I have not added it to the mongoose-attachments module until right now. Meaning: it has not been tested with that same setup.

Have a look at it and if you would like to pull it in I will change our code to use it as part of mongoose-attachments and run our regression tests on it.

Cheers,
Chantal

EDIT: This pull requests includes the commits from https://github.com/firebaseco/mongoose-attachments/pull/9 . I did hope GitHub would remove them once you've accepted No 9 - but it doesn't seem to work that way...
