### PR TITLE
Change and Release Tracking in README.md and CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+0.1.0 (Next Release)
+====================
+
+* [#15](https://github.com/firebaseco/mongoose-attachments/issues/15): Finish provider re-organization
+* [#11](https://github.com/firebaseco/mongoose-attachments/pull/11): Include localfs provider file. (This ticket has evolved and the name is now misleading. The pull request contains part of the re-organization.)
+* [#10](https://github.com/firebaseco/mongoose-attachments/pull/10): FsStorage : provider implementation to store images in local file system
+* [#9](https://github.com/firebaseco/mongoose-attachments/pull/9): README updated with info on registering supported formats
+
+
+
+0.0.4 (19/10/2012)
+==================
+
+* [#7](https://github.com/firebaseco/mongoose-attachments/pull/7): Option to use ImageMagick formats for supportedDecodingFormats
+
+
+
+0.0.3 (27/09/2012)
+==================
+
+* [#4](https://github.com/firebaseco/mongoose-attachments/pull/4): Handling of fs.exists in a backwards compatible way
+
+
+
+0.0.2 (03/07/2012)
+==================
+
+There is no tag for this version.
+
+* [#1](https://github.com/firebaseco/mongoose-attachments/pull/1): Added aws2js based s3 client provider

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Mongoose-Attachments is an attachments plugin for [Mongoose.js](http://mongoosejs.com/). Supports [Amazon S3](http://aws.amazon.com/es/s3/) out-of-the-box and ImageMagick transformations styles.
 
+### Stable Release
+
+You're reading the documentation for the next release of Mongoose-Attachments, which should be 0.1.0.
+The current stable release is [0.0.4](https://github.com/firebaseco/mongoose-attachments/blob/v0.0.4).
+
+Currently, Mongoose-Attachments is undergoing restructuring as we are moving the different storage
+providers into submodules. If you plan to use 0.0.4, do make sure that you use the [documentation for 0.0.4]
+(https://github.com/firebaseco/mongoose-attachments/blob/v0.0.4/README.md).
+
+
 ### Installation
 
     $ npm install mongoose-attachments


### PR DESCRIPTION
As described in https://github.com/firebaseco/mongoose-attachments/issues/15
- added section on stable release to README with links to 0.0.4 and a note that the next release is 0.1.0.
- added CHANGELOG.md with lists of issues (with references to gitub issues) for the next release, for 0.0.4, 0.0.3 and 0.0.2.
