### PR TITLE
Fail if imagemagick is not installed

### DIFF
--- a/lib/attachments.js
+++ b/lib/attachments.js
@@ -1,15 +1,15 @@
 // Copyright (c) 2011-2013 Firebase.co - http://www.firebase.co
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
@@ -155,6 +155,8 @@ var plugin = function(schema, options) {
       fs.stat(attachmentInfo.path, function(err, stats) {
         if(!stats.isFile()) return cb(new Error('path to attach from "' + attachmentInfo.path + '" is not a file'));
         im.identify(attachmentInfo.path, function(err, atts) {
+          if(err) return cb(new Error('identify didn\'t work. Maybe imagemagick is not installed? "' + err + '"'));
+
           // if 'identify' fails, that probably means the file is not an image.
           var canTransform = !!atts && supportedDecodingFormats.indexOf(atts.format) != -1;
           var fileExt = path.extname(attachmentInfo.path);


### PR DESCRIPTION
At the moment errors are ignored when creating images, which lead to weird behavior down the storage chain. mongosse-attachments-localfs will simply die. So if imagemagick is not installed, app will not throw an uncatched error and tell what is wrong.
