### PR TITLE
Support convert attachments that has multi pages

### DIFF
--- a/lib/attachments.js
+++ b/lib/attachments.js
@@ -211,7 +211,10 @@ var plugin = function(schema, options) {
                 var styleFileName = path.basename(attachmentInfo.path, fileExt);
                 styleFileName += '-' + styleName + styleFileExt;
                 var styleFilePath = path.join(path.dirname(attachmentInfo.path), styleFileName);
-                var convertArgs = [attachmentInfo.path]; // source file name
+                // Add '0' index to force first page to be thumbnailed.
+                // Formats that does not multi page support can be outputed same path
+                // even if such index was specified.
+                var convertArgs = [attachmentInfo.path + '[0]']; // source file name
 
                 // add all the transformations args
 


### PR DESCRIPTION
When I uploaded a PDF file that contains multiple pages, I noticed following errors occurred.

```
Error: Command failed: identify: unable to open image `/path/to/tmp/16978-8u61ar-thumb.png': No such file or directory @ error/blob.c/OpenBlob/2644.
identify: unable to open file `/path/to/tmp/16978-8u61ar-thumb.png' @ error/png.c/ReadPNGImage/3851.
```

I entered tmp directory and saw `16978-8u61ar-thumb-0.png` and `16978-8u61ar-thumb-1.png` files.
Later I found the same situation on:
http://stackoverflow.com/questions/12614801/how-to-execute-imagemagick-to-convert-only-the-first-page-of-the-multipage-pdf-t

This PR contains a solution such above URL shows.
